### PR TITLE
Request the IP on the same protocol the current page is served over

### DIFF
--- a/public/squawk.js
+++ b/public/squawk.js
@@ -13,6 +13,6 @@ document.addEventListener("DOMContentLoaded", function(event) {
     ajax=new ActiveXObject("Microsoft.XMLHTTP");
   }
   ajax.onreadystatechange=function() {}
-  ajax.open("GET","http://" + ip, true);
+  ajax.open("GET",window.location.protocol + '//' + ip, true);
   ajax.send();
 });


### PR DESCRIPTION
When you're on an https page (and you should be if you can be) then the browser often wont make an ajax request on an insecure protocol. So rather than hard-code "http://", use the protocol of the requesting page.
