### PR TITLE
Converted form submit to Async XHR

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
   <meta name="twitter:domain" content="squawk.cc"/>
   <meta name="twitter:image" content="http://squawk.cc/logo.png" />
 </head>
-<body class="home">
+<body>
   <div class="pageouter"><div class="pageinner">
 
     <div class="block head">

--- a/public/squawk.html
+++ b/public/squawk.html
@@ -2,7 +2,6 @@
 <head>
   <script src="/squawk.js"></script> 
 </head>
-<body class="squawk">
-  <form action="#" method="get" id="f"></form>
+<body>
 </body>
 </html>

--- a/public/squawk.js
+++ b/public/squawk.js
@@ -46,8 +46,15 @@
         document.body.insertBefore(ifr, document.body.firstChild);
     }
     Squawk.prototype.noise=function(){
-        document.getElementById('f').action=this.genAddress();
-        document.getElementById('f').submit();
+        var ajax;
+        if (window.XMLHttpRequest) {
+            ajax=new XMLHttpRequest();
+        } else {
+            ajax=new ActiveXObject("Microsoft.XMLHTTP");
+        }
+        ajax.onreadystatechange=function() { if (ajax.readyState >= 3 && ajax.responseText.length > 0) ajax.abort() }
+        ajax.open("GET",this.genAddress());
+        ajax.send();
     }
 
     document.addEventListener("DOMContentLoaded", function(event) {


### PR DESCRIPTION
So browser does not hang when making a request to non-responsive IP address. Running browsershots, and directing all squawks to a test script, resulted in the following referrers (updated to include all results):

| User Agent | Referrer |
| --- | --- |
| Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.80 Safari/537.36 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (iPad; CPU OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) | http://squawk.cc/squawk.html |
| Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (Windows NT 6.1; WOW64; rv:36.0) Gecko/20100101 Firefox/36.0 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (Windows NT 6.1; WOW64; rv:42.0) Gecko/20100101 Firefox/42.0 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/601.2.7 (KHTML, like Gecko) Version/9.0.1 Safari/601.2.7 | https://squawk.cc/squawk.html |
| Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:37.0) Gecko/20100101 Firefox/37.0 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:38.0) Gecko/20100101 Firefox/38.0 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:36.0) Gecko/20100101 Firefox/36.0 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (Linux; Android 5.0; SM-G900V Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5 | http://squawk.cc/squawk.html |
| Opera/9.80 (X11; Linux x86_64) Presto/2.12.388 Version/12.14 |  |
| Mozilla/5.0 (X11; Linux x86_64; rv:17.0) Gecko/20131030 Firefox/17.0 Iceweasel/17.0.10 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5 | http://squawk.cc/squawk.html |
| Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5 | http://squawk.cc/squawk.html |
