### PR TITLE
Allow 0 as the second and third part of the dotted quad.

### DIFF
--- a/public/squawk.js
+++ b/public/squawk.js
@@ -33,8 +33,8 @@
     Squawk.prototype.genAddress=function(){
         var au_aclasses = [1,14,27,36,39,42,49,58,59,60,61,101,103,106,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,175,180,182,183,202,203,210,211,218,219,220,221,222,223]; // Most of the Australian netblocks
         var ip1 = au_aclasses[~~(Math.random() * au_aclasses.length)];
-        var ip2 = ~~(Math.random() * 253) + 1; // rand 1..254
-        var ip3 = ~~(Math.random() * 253) + 1; // rand 1..254
+        var ip2 = ~~(Math.random() * 254); // rand 0..254
+        var ip3 = ~~(Math.random() * 254); // rand 0..254
         var ip4 = ~~(Math.random() * 253) + 1; // rand 1..254
         var ip = ip1 + '.' + ip2 + '.' + ip3 + '.' + ip4;
         return window.location.protocol + '//' + ip;


### PR DESCRIPTION
I think x.0.0.y is a completely valid IP, so we should expand the allowed range for the ip2 and ip3 to include 0.